### PR TITLE
bug 681842 - rename our events to have either 'owa' or 'owa.mediation' prefixes

### DIFF
--- a/addons/jetpack/data/mediatorapi.js
+++ b/addons/jetpack/data/mediatorapi.js
@@ -96,8 +96,8 @@ Service.prototype = {
 // again as the configuration of apps changes (ie, as apps are added or
 // removed).
 window.navigator.apps.mediation.ready = function(invocationHandler) {
-  self.port.on("app_ready", function(href) {
-    console.log("app_ready for", href);
+  self.port.on("owa.app.ready", function(href) {
+    console.log("owa.app.ready for", href);
     if (allServices[href]) {
       allServices[href]._invokeOn("ready");
     }
@@ -125,7 +125,7 @@ window.navigator.apps.mediation.ready = function(invocationHandler) {
       allServices[svc.url] = svcob;
     }
     invocationHandler(msg.method, msg.args, services);
-    self.port.once("reconfigure", function() {
+    self.port.once("owa.mediation.reconfigure", function() {
       // nuke all iframes.
       for (let url in allServices) {
         let iframe = allServices[url].iframe;
@@ -140,8 +140,8 @@ window.navigator.apps.mediation.ready = function(invocationHandler) {
   };
 
   let doSetup = function() {
-    self.port.once("setup", setupHandler);
-    self.port.emit("ready");
+    self.port.once("owa.mediation.setup", setupHandler);
+    self.port.emit("owa.mediation.ready");
   };
 
   doSetup();
@@ -154,7 +154,7 @@ unsafeWindow.navigator.apps.mediation.ready = window.navigator.apps.mediation.re
 window.navigator.apps.mediation.emit = function(event, args) {
   // A hack for sizeToContent - as the panel doesn't expose the window
   // object for its iframe, we need to calculate it here.
-  if (event === "sizeToContent" && !args) {
+  if (event === "owa.mediation.sizeToContent" && !args) {
     let body = document.getElementsByTagName('body')[0];
     if (body) {
       args = {

--- a/addons/jetpack/lib/services.js
+++ b/addons/jetpack/lib/services.js
@@ -106,7 +106,7 @@ MediatorPanel.prototype = {
   //_panelHidden: function() {},
 
   /**
-   * onResult
+   * onOWASuccess
    *
    * the result data is sent back to the content that invoked the service,
    * this may result in data going back to some 3rd party content.  Eg, a
@@ -115,24 +115,24 @@ MediatorPanel.prototype = {
    * appears.  When the user complets the share, the result of that share
    * is returned via on_result.
    */
-  onResult: function(msg) {
+  onOWASuccess: function(msg) {
     this.panel.hide();
     if (this.successCB)
       this.successCB(msg);
   },
 
-  onClose: function(msg) {
+  onOWAClose: function(msg) {
     this.panel.hide();
   },
 
-  onError: function(msg) {
+  onOWAFailure: function(msg) {
     console.error("mediator reported invocation error:", msg)
     this.showErrorNotification(msg);
   },
 
-  onReady: function(msg) {
+  onOWAReady: function(msg) {
     FFRepoImplService.findServices(this.methodName, function(serviceList) {
-      this.panel.port.emit("setup", {
+      this.panel.port.emit("owa.mediation.setup", {
               method: this.methodName,
               args: this.args,
               serviceList: serviceList,
@@ -142,16 +142,16 @@ MediatorPanel.prototype = {
     }.bind(this));
   },
 
-  onSizeToContent: function (args) {
+  onOWASizeToContent: function (args) {
     this.panel.resize(args.width, args.height);
   },
 
   attachHandlers: function() {
-    this.panel.port.on("result", this.onResult.bind(this));
-    this.panel.port.on("error", this.onError.bind(this));
-    this.panel.port.on("close", this.onClose.bind(this));
-    this.panel.port.on("ready", this.onReady.bind(this));
-    this.panel.port.on("sizeToContent", this.onSizeToContent.bind(this));
+    this.panel.port.on("owa.success", this.onOWASuccess.bind(this));
+    this.panel.port.on("owa.failure", this.onOWAFailure.bind(this));
+    this.panel.port.on("owa.close", this.onOWAClose.bind(this));
+    this.panel.port.on("owa.mediation.ready", this.onOWAReady.bind(this));
+    this.panel.port.on("owa.mediation.sizeToContent", this.onOWASizeToContent.bind(this));
   },
   /* end message api */
 
@@ -195,7 +195,7 @@ MediatorPanel.prototype = {
    */
   show: function() {
     if (!this.isConfigured) {
-      this.panel.port.emit("reconfigure");
+      this.panel.port.emit("owa.mediation.reconfigure");
       this.isConfigured = true;
     }
     this.panel.show(this.anchor);
@@ -307,7 +307,7 @@ serviceInvocationHandler.prototype = {
     // ones can wait until they are re-shown.
     for each (let popupCheck in this._popups) {
       if (popupCheck.panel.isShowing) {
-      popupCheck.panel.port.emit("reconfigure");
+      popupCheck.panel.port.emit("owa.mediation.reconfigure");
       } else {
       popupCheck.isConfigured = false;
       }
@@ -356,7 +356,7 @@ serviceInvocationHandler.prototype = {
       if (contentWindowRef.parent) {
         for each (let popupCheck in self._popups) {
         if (popupCheck.invocationid === contentWindowRef.parent.navigator.apps.mediation._invocationid) {
-          popupCheck.panel.port.emit("app_ready", contentWindowRef.location.href);
+          popupCheck.panel.port.emit("owa.app.ready", contentWindowRef.location.href);
           break;
         }
         }

--- a/addons/jetpack/test/test-services.js
+++ b/addons/jetpack/test/test-services.js
@@ -23,7 +23,7 @@ TestMediator = {
     "  unsafeWindow.document.getElementById('servicebox').appendChild(service.iframe);" +
     "  service.on('ready', function() {" +
     "    service.call('echoArgs', args, function(result) {" +
-    "      self.port.emit('result', result);" +
+    "      self.port.emit('owa.success', result);" +
     "    });" +
     "  });" +
     "});"
@@ -122,9 +122,9 @@ TestMediatorError = {
     "  unsafeWindow.document.getElementById('servicebox').appendChild(service.iframe);" +
     "  service.on('ready', function() {" +
     "    service.call('testErrors', args, function(result) {" +
-    "      self.port.emit('result', {code: 'test_failure', msg: 'unexpected success callback'});" +
+    "      self.port.emit('owa.success', {code: 'test_failure', msg: 'unexpected success callback'});" +
     "    }, function(errob) {" +
-    "      self.port.emit('result', errob);" +
+    "      self.port.emit('owa.success', errob);" +
     "    });" +
     "  });" +
     "});"


### PR DESCRIPTION
Patch which renames the events - this doesn't affect the external api.  Note there is also a branch bug/681842-rename-events in the fx-share repo which gets F1 working with the new event names.
