### PR TITLE
Bug 689276: Fix install() signature and remove unused setRepoOrigin

### DIFF
--- a/addons/jetpack/lib/main.js
+++ b/addons/jetpack/lib/main.js
@@ -136,7 +136,11 @@ openwebapps.prototype = {
       name: "install",
       script: null,
       getapi: function(contentWindowRef) {
-        return function(args) {
+        return function(origin, data, onsuccess, onerror) {
+          let args = {
+            url: origin, install_data: data,
+            onsuccess: onsuccess, onerror: onerror
+          };
           repo.install(contentWindowRef.location, args, win);
         }
       }
@@ -159,14 +163,6 @@ openwebapps.prototype = {
         return function(callback) {
           repo.getInstalledBy(contentWindowRef.location, callback);
         }
-      }
-    });
-    win.appinjector.register({
-      apibase: "navigator.mozApps",
-      name: "setRepoOrigin",
-      script: null,
-      getapi: function() {
-        return function(args) {}
       }
     });
 


### PR DESCRIPTION
install() takes 4 arguments now instead of 1 JS object. This patch fixes the call to the injector so that we don't have to change the code in api.js.

Also, setRepoOrigin is unused, thus removed.
