### PR TITLE
Allow a fuller range of eventemitter functionality in the mediator. 

### DIFF
--- a/addons/jetpack/data/mediatorapi.js
+++ b/addons/jetpack/data/mediatorapi.js
@@ -177,24 +177,33 @@ window.navigator.mozApps.mediation.ready = function(invocationHandler) {
 
 unsafeWindow.navigator.mozApps.mediation.ready = window.navigator.mozApps.mediation.ready;
 
-window.navigator.mozApps.mediation.emit = function(event, args) {
-  // A hack for sizeToContent - as the panel doesn't expose the window
-  // object for its iframe, we need to calculate it here.
-  if (event === "owa.mediation.sizeToContent" && !args) {
-    // hrmph - we used to use document.getElementsByTagName('body')[0], but
-    // sometimes that returns undefined while document.body always works.
-    let body = document.body;
-    if (body) {
-      args = {
-        width: body.scrollWidth,
-        height: body.scrollHeight
-      };
-    }
-  }
-  self.port.emit(event, args)
-}
 
-unsafeWindow.navigator.mozApps.mediation.emit = window.navigator.mozApps.mediation.emit;
+var mPort = {
+    emit: function (event, args) {
+      // A hack for sizeToContent - as the panel doesn't expose the window
+      // object for its iframe, we need to calculate it here.
+      if (event === "owa.mediation.sizeToContent" && !args) {
+        // hrmph - we used to use document.getElementsByTagName('body')[0], but
+        // sometimes that returns undefined while document.body always works.
+        let body = document.body;
+        if (body) {
+          args = {
+            width: body.scrollWidth,
+            height: body.scrollHeight
+          };
+        }
+      }
+      self.port.emit(event, args)
+    },
+    on: function (event, fn) {
+      self.port.on(event, fn);
+    },
+    removeListener: function (event, fn) {
+      self.port.removeListener(event, fn);
+    }
+};
+
+unsafeWindow.navigator.mozApps.mediation.port = mPort;
 
 window.navigator.mozApps.mediation.invokeService = function(iframe, activity, message, callback) {//XX error cb?
   function callbackShim(result) {

--- a/addons/jetpack/data/service.js
+++ b/addons/jetpack/data/service.js
@@ -55,16 +55,16 @@ var addServicesService = new Service({
 });
 
 function confirm() {
-  var emit = window.navigator.mozApps.mediation.emit;
+  var port = window.navigator.mozApps.mediation.port;
   var selected = $("#services").tabs('option', 'selected'); // => 0
   var service = gServiceList[selected].call("confirm", {}, function(status) {
     var messageData = {
       app: iframe.contentWindow.location.href,
       result: "ok"
     };
-    emit("result", messageData);
+    port.emit("result", messageData);
   }, function(err) {
-    emit("error", err);
+    port.emit("error", err);
   });
 }
 


### PR DESCRIPTION
Allow a fuller range of eventemitter functionality in the mediator. Change done as part of a pair programming session with @mixedpuppy.

Part of fixing [bug #689696](https://bugzilla.mozilla.org/show_bug.cgi?id=689696). See that bug for more detail, and [this fx-share-addon pull request](https://github.com/mozilla/fx-share-addon/pull/16) for how the functionality is used.
