### PR TITLE
Reconfigure all apps when the user clears all active logins

### DIFF
--- a/addons/jetpack/lib/services.js
+++ b/addons/jetpack/lib/services.js
@@ -426,6 +426,7 @@ function serviceInvocationHandler(win)
   let observerService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
   observerService.addObserver(this, "openwebapp-installed", false);
   observerService.addObserver(this, "openwebapp-uninstalled", false);
+  observerService.addObserver(this, "net:clear-active-logins", false);
   
   // if we open a new tab, close any mediator panels
   win.gBrowser.tabContainer.addEventListener("TabOpen", function(e) {
@@ -477,7 +478,9 @@ serviceInvocationHandler.prototype = {
    * reset our mediators if an app is installed or uninstalled
    */
   observe: function(subject, topic, data) {
-    if (topic === "openwebapp-installed" || topic === "openwebapp-uninstalled")
+    if (topic === "openwebapp-installed" ||
+        topic === "openwebapp-uninstalled" ||
+        topic === "net:clear-active-logins")
     {
     // All visible panels need to be reconfigured now, while invisible
     // ones can wait until they are re-shown.


### PR DESCRIPTION
When all active logins are cleared, we reconfigure all mediators.  While this isn't the complete story (ie, it doesn't arrange to actually clear credentials), it isn't a short-term hack just for F1 - thus it is based on the develop branch.
