### PR TITLE
Bug/692977 pagemod api

### DIFF
--- a/addons/jetpack/data/about.js
+++ b/addons/jetpack/data/about.js
@@ -24,6 +24,11 @@
  * Contributor(s):
  **/
 
+// XXX TODO
+// get access to the injected api's, will remove later when api
+// injection method changes.
+var mozApps = unsafeWindow.navigator.wrappedJSObject.mozApps;
+
 self.port.on('data-url', function(baseurl) {
   // attach our css file
   var fileref=document.createElement("link")
@@ -31,11 +36,6 @@ self.port.on('data-url', function(baseurl) {
   fileref.setAttribute("type", "text/css")
   fileref.setAttribute("href", baseurl+"skin/about.css");
   document.getElementsByTagName("head")[0].appendChild(fileref)
-
-  // XXX TODO
-  // get access to the injected api's, will remove later when api
-  // injection method changes.
-  window.navigator.mozApps = unsafeWindow.navigator.mozApps;
 });
 
 function elem(type, clazz) {
@@ -50,7 +50,7 @@ var appDict;
 function refresh() {
   if (!pending) {
     pending = true;
-    navigator.mozApps.mgmt.list(function(aList) {
+    mozApps.mgmt.list(function(aList) {
       let aDict = {};
       for (let i = 0; i < aList.length; i++) {
         aDict[aList[i].origin] = aList[i];
@@ -184,13 +184,13 @@ function render() {
 
       function makeLaunchFn(appID) {
         return function() {
-          navigator.mozApps.mgmt.launch(appID);
+          mozApps.mgmt.launch(appID);
         }
       }
 
       function makeDeleteFn(appID, container) {
         return function() {
-          navigator.mozApps.mgmt.uninstall(appID, function() {});
+          mozApps.mgmt.uninstall(appID, function() {});
           container.style.minHeight = "0px";
           container.style.height = container.clientHeight + "px";
           window.setTimeout(function() {

--- a/addons/jetpack/data/mediatorapi.js
+++ b/addons/jetpack/data/mediatorapi.js
@@ -1,15 +1,9 @@
 /* -*- Mode: JavaScript; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set ts=2 et sw=2 tw=80: */
 
-// The mediation API.  This script is injected by jetpack into all mediators.
-if (!window.navigator.mozApps) window.navigator.mozApps = {}
-if (!window.navigator.mozApps.mediation) window.navigator.mozApps.mediation = {}
-
 // Insert the mediator api into unsafeWindow
-if (!unsafeWindow.navigator.mozApps)
-  unsafeWindow.navigator.mozApps = window.navigator.mozApps;
 if (!unsafeWindow.navigator.mozApps.mediation)
-  unsafeWindow.navigator.mozApps.mediation = window.navigator.mozApps.mediation;
+  unsafeWindow.navigator.mozApps.mediation = {};
 
 let allServices = {} // keyed by handler URL.
 // This object should look very much like the Service object in repo.js
@@ -131,7 +125,7 @@ self.port.on("owa.mediation.onLogin", function(params) {
   });
 });
 
-window.navigator.mozApps.mediation.startLogin = function(origin) {
+unsafeWindow.navigator.mozApps.mediation.startLogin = function(origin) {
   allServices[origin].call("getParameters", {}, function(params) {
     // due to a limitation in our implementation, this getParameters call is
     // actually made on the "main" service rather than on the login specific
@@ -140,13 +134,12 @@ window.navigator.mozApps.mediation.startLogin = function(origin) {
     self.port.emit("owa.mediation.doLogin", {app: origin, auth: params.auth})
   });
 }
-unsafeWindow.navigator.mozApps.mediation.startLogin = window.navigator.mozApps.mediation.startLogin;
 
 // The API called by the mediator when it is ready to go.
 // Note the invocation handler will be called once initially, and possibly
 // again as the configuration of apps changes (ie, as apps are added or
 // removed).
-window.navigator.mozApps.mediation.ready = function(invocationHandler) {
+unsafeWindow.navigator.mozApps.mediation.ready = function(invocationHandler) {
   self.port.on("owa.app.ready", function(origin) {
     //console.log("owa.app.ready for", origin);
     if (allServices[origin]) {
@@ -218,7 +211,6 @@ window.navigator.mozApps.mediation.ready = function(invocationHandler) {
   // event per app.
 };
 
-unsafeWindow.navigator.mozApps.mediation.ready = window.navigator.mozApps.mediation.ready;
 
 
 var mPort = {

--- a/addons/jetpack/data/mediatorapi.js
+++ b/addons/jetpack/data/mediatorapi.js
@@ -2,8 +2,8 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 
 // Insert the mediator api into unsafeWindow
-if (!unsafeWindow.navigator.mozApps.mediation)
-  unsafeWindow.navigator.mozApps.mediation = {};
+if (!unsafeWindow.navigator.wrappedJSObject.mozApps.mediation)
+  unsafeWindow.navigator.wrappedJSObject.mozApps.mediation = {};
 
 let allServices = {} // keyed by handler URL.
 // This object should look very much like the Service object in repo.js
@@ -125,7 +125,7 @@ self.port.on("owa.mediation.onLogin", function(params) {
   });
 });
 
-unsafeWindow.navigator.mozApps.mediation.startLogin = function(origin) {
+unsafeWindow.navigator.wrappedJSObject.mozApps.mediation.startLogin = function(origin) {
   allServices[origin].call("getParameters", {}, function(params) {
     // due to a limitation in our implementation, this getParameters call is
     // actually made on the "main" service rather than on the login specific
@@ -139,7 +139,7 @@ unsafeWindow.navigator.mozApps.mediation.startLogin = function(origin) {
 // Note the invocation handler will be called once initially, and possibly
 // again as the configuration of apps changes (ie, as apps are added or
 // removed).
-unsafeWindow.navigator.mozApps.mediation.ready = function(invocationHandler) {
+unsafeWindow.navigator.wrappedJSObject.mozApps.mediation.ready = function(invocationHandler) {
   self.port.on("owa.app.ready", function(origin) {
     //console.log("owa.app.ready for", origin);
     if (allServices[origin]) {
@@ -151,7 +151,7 @@ unsafeWindow.navigator.mozApps.mediation.ready = function(invocationHandler) {
     //console.log("setup event has", msg.serviceList.length, "services");
     // We record the invocation ID in the mediator window so we can later
     // link the "app ready" calls back to the specific mediator instance.
-    unsafeWindow.navigator.mozApps.mediation._invocationid = msg.invocationid;
+    unsafeWindow.navigator.wrappedJSObject.mozApps.mediation._invocationid = msg.invocationid;
     let document = unsafeWindow.document;
 
     // TODO: do not create iframes when mediators are converted to templates,
@@ -237,4 +237,4 @@ var mPort = {
       self.port.removeListener(event, fn);
     }
 };
-unsafeWindow.navigator.mozApps.mediation.port = mPort;
+unsafeWindow.navigator.wrappedJSObject.mozApps.mediation.port = mPort;

--- a/addons/jetpack/data/mgmtapi.js
+++ b/addons/jetpack/data/mgmtapi.js
@@ -1,0 +1,88 @@
+
+if (!window.navigator.mozApps)
+  window.navigator.mozApps = {}
+
+// Insert the services api into unsafeWindow
+if (!unsafeWindow.navigator.mozApps)
+  unsafeWindow.navigator.mozApps = window.navigator.mozApps;
+
+var callid = 0;
+
+function _makeCall(msg, args, callback, errcb) {
+  let data = {
+    location: location.href,
+    data: args
+  }
+  callid++;
+  if (callback) {
+    data.success = msg+".success."+callid;
+    self.port.once(data.success, function(data) {
+      //dump("msg "+msg+" got "+JSON.stringify(data)+"\n");
+      if (errcb)
+        self.port.removeListener(errcb);
+      callback(data);
+    });
+  }
+  if (errcb) {
+    data.error = msg+".error."+callid;
+    self.port.once(data.error, function(data) {
+      if (callback)
+        self.port.removeListener(callback);
+      errcb(data);
+    });
+  }
+  //dump("making call to "+msg+"\n");
+  self.port.emit(msg, data);
+}
+
+let _watches = [];
+function _updateWatchers() {
+  for (var i=0; i < _watches.length; i++) {
+    _watches[i](arguments);
+  }
+}
+function _clearWatcher(fn) {
+  let idx = _watches.indexOf(fn);
+  if (idx >= 0) {
+    _watches.splice(idx, 1);
+  }
+}
+
+window.navigator.mozApps.mgmt = {
+  launch: function(args) {
+    // no return, just emit the message
+    _makeCall('owa.mgmt.launch', args);
+  },
+  list: function(callback) {
+    _makeCall('owa.mgmt.list', null, callback);
+  },
+  loginStatus: function(args, callback) {
+    _makeCall('owa.mgmt.loginStatus', args, callback);
+  },
+  loadState: function(callback) {
+    _makeCall('owa.mgmt.loadState', null, callback);
+  },
+  saveState: function(state, callback) {
+    _makeCall('owa.mgmt.saveState', state, callback);
+  },
+  uninstall: function(key, callback, onerror) {
+    _makeCall('owa.mgmt.uninstall', key, callback, onerror);
+  },
+  watchUpdates: function(callback) {
+    _watches.push(callback);
+    let idx = _watches.indexOf(callback);
+    if (idx == 0) {
+      self.port.on("owa.mgmt.update", _updateWatchers);
+      _makeCall('owa.mgmt.watchUpdates');
+    }
+  },
+  clearWatch: function(callback) {
+    _clearWatcher(callback);
+    if (_watches.length < 1) {
+      _makeCall('owa.mgmt.clearWatch');
+      self.port.removeListener("owa.mgmt.update", _updateWatchers);
+    }
+  }
+}
+
+unsafeWindow.navigator.mozApps.mgmt = window.navigator.mozApps.mgmt;

--- a/addons/jetpack/data/mgmtapi.js
+++ b/addons/jetpack/data/mgmtapi.js
@@ -1,10 +1,5 @@
 
-if (!window.navigator.mozApps)
-  window.navigator.mozApps = {}
 
-// Insert the services api into unsafeWindow
-if (!unsafeWindow.navigator.mozApps)
-  unsafeWindow.navigator.mozApps = window.navigator.mozApps;
 
 var callid = 0;
 
@@ -48,7 +43,7 @@ function _clearWatcher(fn) {
   }
 }
 
-window.navigator.mozApps.mgmt = {
+unsafeWindow.navigator.mozApps.mgmt = {
   launch: function(args) {
     // no return, just emit the message
     _makeCall('owa.mgmt.launch', args);
@@ -85,4 +80,3 @@ window.navigator.mozApps.mgmt = {
   }
 }
 
-unsafeWindow.navigator.mozApps.mgmt = window.navigator.mozApps.mgmt;

--- a/addons/jetpack/data/mgmtapi.js
+++ b/addons/jetpack/data/mgmtapi.js
@@ -43,7 +43,7 @@ function _clearWatcher(fn) {
   }
 }
 
-unsafeWindow.navigator.mozApps.mgmt = {
+unsafeWindow.navigator.wrappedJSObject.mozApps.mgmt = {
   launch: function(args) {
     // no return, just emit the message
     _makeCall('owa.mgmt.launch', args);

--- a/addons/jetpack/data/servicesapi.js
+++ b/addons/jetpack/data/servicesapi.js
@@ -1,14 +1,10 @@
 
 if (!window.navigator.mozApps)
   window.navigator.mozApps = {}
-if (!window.navigator.mozApps.services)
-  window.navigator.mozApps.services = {}
 
 // Insert the services api into unsafeWindow
 if (!unsafeWindow.navigator.mozApps)
   unsafeWindow.navigator.mozApps = window.navigator.mozApps;
-if (!unsafeWindow.navigator.mozApps.mediation) 3
-  unsafeWindow.navigator.mozApps.services = window.navigator.mozApps.services;
 
 var activities = {};
 var origin = null;

--- a/addons/jetpack/data/servicesapi.js
+++ b/addons/jetpack/data/servicesapi.js
@@ -3,7 +3,7 @@ var activities = {};
 var origin = null;
 var callid = 0;
 
-unsafeWindow.navigator.mozApps.services = {
+unsafeWindow.navigator.wrappedJSObject.mozApps.services = {
   // notify our mediator that we're ready for business.
   ready: function() {
     self.port.emit("owa.service.ready", origin);

--- a/addons/jetpack/data/servicesapi.js
+++ b/addons/jetpack/data/servicesapi.js
@@ -1,16 +1,9 @@
 
-if (!window.navigator.mozApps)
-  window.navigator.mozApps = {}
-
-// Insert the services api into unsafeWindow
-if (!unsafeWindow.navigator.mozApps)
-  unsafeWindow.navigator.mozApps = window.navigator.mozApps;
-
 var activities = {};
 var origin = null;
 var callid = 0;
 
-window.navigator.mozApps.services = {
+unsafeWindow.navigator.mozApps.services = {
   // notify our mediator that we're ready for business.
   ready: function() {
     self.port.emit("owa.service.ready", origin);
@@ -69,4 +62,3 @@ self.port.on("owa.service.invoke", function(args) {
   }
 });
 
-unsafeWindow.navigator.mozApps.services = window.navigator.mozApps.services;

--- a/addons/jetpack/lib/injector.js
+++ b/addons/jetpack/lib/injector.js
@@ -43,38 +43,18 @@
 
 const { Cc, Ci, Cu } = require("chrome");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+const xulApp = require("api-utils/xul-app");
 
-const ALL_GROUP_CONSTANT = "___all___";
-let refreshed;
+const HAS_NAVIGATOR_INJECTOR =
+        xulApp.versionInRange(xulApp.version, "9.0a2", "*");
 
-let Injector = {
-  // Injector will inject code into the browser content.  The provider class
-  // looks like:
-  //  var someapiprovider = {
-  //    apibase: null, // null == 'navigator.mozilla.labs', or define your own namespace
-  //    name: 'my_fn_name', // builds to 'navigator.mozilla.labs.my_fn_name'
-  //    script: null, // null == use injected default script or provide your own
-  //    getapi: function() {
-  //      let someobject = somechromeobject;
-  //      return function() {
-  //        someobject();
-  //      }
-  //    }
-  //  }
-  //  InjectorInit(window); // set injector on window
-  //  injector.register(someapiprovider);
-  //
-  //  With the above object, there would be a new api in content that can
-  //  be used from any webpage like:
-  //
-  //  navigator.mozilla.labs.my_fn_name();
-  //**************************************************************************//
-  //
-  _scriptToInject: function(provider) {
-    // a provider may use it's own script to inject its api
-    if (provider.script) return provider.script;
-
-    // otherwise, use a builtin injector script that we load from this
+function NavigatorInjector() {
+  console.log("initalize NavigatorInjector");
+  this.onLoad();
+}
+NavigatorInjector.prototype = {
+  _scriptToInject: function(entry, fname) {
+    // use a builtin injector script that we load from this
     // function object:
     let script = (function() {
       // __API_* strings are replaced in injector.js with specifics from
@@ -89,12 +69,15 @@ let Injector = {
       }
       api[fname] = this['__API_INJECTED__'];
       delete this['__API_INJECTED__'];
-      //dump("injected: "+eval(apibase+'.'+fname)+"\n");
+      //console.log("injected: "+apibase+'.'+fname+" "+eval(apibase+'.'+fname)+"\n");
     }).toString();
 
-    let apibase = provider.apibase ? provider.apibase : 'navigator.mozilla.labs';
-    script = script.replace(/__API_BASE__/g, apibase).replace(/__API_NAME__/g, provider.name).replace(/__API_INJECTED__/g, '__mozilla_injected_api_' + (provider.mangledName ? provider.mangledName : provider.name) + '__');
-    //dump(script+"\n");
+    let apibase = 'navigator.'+entry;
+    let mangledName = entry+"_"+fname;
+    script = script.replace(/__API_BASE__/g, apibase).
+                    replace(/__API_NAME__/g, fname).
+                    replace(/__API_INJECTED__/g, '__navigator_injected_api_' + mangledName + '__');
+    //console.log(script+"\n");
     // return a wrapped script that executes the function
     return "(" + script + ")();";
   },
@@ -104,88 +87,65 @@ let Injector = {
    *
    * Injects the content API into the specified DOM window.
    */
-  _inject: function(win, provider) {
+  _inject: function(aWindow, entry, fname, fn) {
     // ensure we're dealing with a wrapped native
-    var safeWin = new XPCNativeWrapper(win);
-    // options here are ignored for 3.6
+    let mangledName = entry+"_"+fname;
+    var safeWin = new XPCNativeWrapper(aWindow);
     let sandbox = new Cu.Sandbox(safeWin, {
-      sandboxProto: safeWin,
+      sandboxProto: aWindow,
       wantXrays: true
     });
-/*let sandbox = new Cu.Sandbox(
-        Cc["@mozilla.org/systemprincipal;1"].
-           createInstance(Ci.nsIPrincipal),
-    );*/
 
-    sandbox.importFunction(provider.getapi(safeWin), '__mozilla_injected_api_' + (provider.mangledName ? provider.mangledName : provider.name) + '__');
+    sandbox.importFunction(fn, '__navigator_injected_api_' + mangledName + '__');
     sandbox.window = safeWin;
     sandbox.navigator = safeWin.navigator.wrappedJSObject;
-    Cu.evalInSandbox(this._scriptToInject(provider), sandbox, "1.8");
-  }
+    Cu.evalInSandbox(this._scriptToInject(entry, fname), sandbox, "1.8");
+  },
 
-};
+  createProperties: function(aWindow) {
+    //console.log("createProperties for "+aWindow.location);
+    try {
+      const CATEGORY_TO_ENUMERATE = "JavaScript-navigator-property";
+      var cm = Cc["@mozilla.org/categorymanager;1"].getService(Ci.nsICategoryManager);
+      var enumerator = cm.enumerateCategory(CATEGORY_TO_ENUMERATE);
+      var entries = [];
+      while (enumerator.hasMoreElements()) {
+          var item = enumerator.getNext();
+          var entry = item.QueryInterface(Ci.nsISupportsCString)
+          var value = cm.getCategoryEntry(CATEGORY_TO_ENUMERATE, entry.toString());
+          entries.push([entry, value]);
+          var p = Cc[value].createInstance(Ci.nsIDOMGlobalPropertyInitializer);
+          var obj = p.init(aWindow);
 
-
-
-// hook up a separate listener for each xul window
-
-function InjectorInit(window) {
-  if (window.appinjector) return;
-  window.appinjector = {
-    providers: [],
-    actions: [],
-    onLoad: function() {
-      var obs = Cc["@mozilla.org/observer-service;1"].
-      getService(Ci.nsIObserverService);
-      obs.addObserver(this, 'content-document-global-created', false);
-    },
-
-    onUnload: function() {
-      var obs = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
-      obs.removeObserver(this, 'content-document-global-created');
-    },
-
-    register: function(provider) {
-      this.providers.push(provider);
-    },
-    registerAction: function(action) {
-      this.actions.push(action);
-    },
-
-    observe: function(aSubject, aTopic, aData) {
-      //if (!aSubject.location.href) return;
-      // is this window a child of OUR XUL window?
-      let mainWindow = aSubject.QueryInterface(Ci.nsIInterfaceRequestor).getInterface(Ci.nsIWebNavigation).QueryInterface(Ci.nsIDocShellTreeItem).rootTreeItem.QueryInterface(Ci.nsIInterfaceRequestor).getInterface(Ci.nsIDOMWindow);
-      // *sob* - this check prevents the API from being injected in content
-      // loaded into a jetpack panel...
-      // if (mainWindow != window) {
-      //  return;
-      // }
-      for (let i in this.actions) {
-        this.actions[i]();
-      }
-      for (let i in this.providers) {
-        //dump("injecting api "+this.providers[i].name+"\n");
-        Injector._inject(aSubject, this.providers[i]);
-      }
-    },
-
-    inject: function() {
-      // arrange to setup windows created in the future...
-      window.appinjector.onLoad();
-      window.addEventListener("unload", function() window.appinjector.onUnload(), false);
-      // and setup Windows which exist now.
-      let browsers = window.document.querySelectorAll("tabbrowser");
-      for (let i = 0; i < browsers.length; i++) {
-        for (let j = 0; j < browsers[i].browsers.length; j++) {
-          let cw = browsers[i].browsers[j].contentWindow;
-          if (cw) {
-            window.appinjector.observe(cw);
+          for (var fn in obj) {
+            this._inject(aWindow, entry, fn, obj[fn]);
           }
-        }
       }
+    } catch(e) {
+      console.log(e.toString());
     }
-  };
+  },
+
+  onLoad: function() {
+    var obs = Cc["@mozilla.org/observer-service;1"].
+    getService(Ci.nsIObserverService);
+    obs.addObserver(this, 'content-document-global-created', false);
+  },
+
+  onUnload: function() {
+    var obs = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
+    obs.removeObserver(this, 'content-document-global-created');
+  },
+
+  observe: function(aWindow, aTopic, aData) {
+    this.createProperties(aWindow);
+  }
 }
 
-exports.InjectorInit = InjectorInit;
+var gInjector;
+exports.init = function() {
+  if (!HAS_NAVIGATOR_INJECTOR)
+    gInjector = new NavigatorInjector();
+}
+
+

--- a/addons/jetpack/lib/injector.js
+++ b/addons/jetpack/lib/injector.js
@@ -48,6 +48,17 @@ const xulApp = require("api-utils/xul-app");
 const HAS_NAVIGATOR_INJECTOR =
         xulApp.versionInRange(xulApp.version, "9.0a2", "*");
 
+/**
+ * NavigatorInjector
+ *
+ * this class backfills support for the JavaScript-navigator-property category
+ * used by nsIDOMGlobalPropertyInitializer, which was added for fx9.  Any
+ * module that wants to add properties onto the navigator object should do so
+ * using nsIDOMGlobalPropertyInitializer.  Ideally only one instance of this
+ * class would be run in a single process of firefox (ie. it should be an
+ * xpcom service.). NavigatorInjector will only initialize in firefox 8 or
+ * earlier.
+ */
 function NavigatorInjector() {
   console.log("initalize NavigatorInjector");
   this.onLoad();

--- a/addons/jetpack/lib/injector.js
+++ b/addons/jetpack/lib/injector.js
@@ -58,6 +58,22 @@ const HAS_NAVIGATOR_INJECTOR =
  * class would be run in a single process of firefox (ie. it should be an
  * xpcom service.). NavigatorInjector will only initialize in firefox 8 or
  * earlier.
+ *
+ * Once you call init() in this module, you do not need to do anything else
+ * so long as you have registered your api like:
+
+  // register the class that implements nsIDOMGlobalPropertyInitializer
+  Cm.QueryInterface(Ci.nsIComponentRegistrar).registerFactory(
+    MozAppsAPIClassID, "MozAppsAPI", MozAppsAPIContract, MozAppsAPIFactory
+  );
+  // register the category and contract for our api
+  Cc["@mozilla.org/categorymanager;1"].getService(Ci.nsICategoryManager).
+              addCategoryEntry("JavaScript-navigator-property", "mozApps",
+                      MozAppsAPIContract,
+                      false, true);
+
+ * see openwebapps/addon/jetpack/lib/main.js for an implementation of the
+ * above classes.
  */
 function NavigatorInjector() {
   console.log("initalize NavigatorInjector");
@@ -113,7 +129,7 @@ NavigatorInjector.prototype = {
     Cu.evalInSandbox(this._scriptToInject(entry, fname), sandbox, "1.8");
   },
 
-  createProperties: function(aWindow) {
+  _createProperties: function(aWindow) {
     //console.log("createProperties for "+aWindow.location);
     try {
       const CATEGORY_TO_ENUMERATE = "JavaScript-navigator-property";
@@ -149,7 +165,7 @@ NavigatorInjector.prototype = {
   },
 
   observe: function(aWindow, aTopic, aData) {
-    this.createProperties(aWindow);
+    this._createProperties(aWindow);
   }
 }
 

--- a/addons/jetpack/lib/main.js
+++ b/addons/jetpack/lib/main.js
@@ -334,7 +334,6 @@ function setupAboutPageMods() {
  * to allow other addons with owa as a dependency to have a reliable
  * way to initialize per-window.
  */
-var gInjector;
 function startup(getUrlCB) { /* Initialize simple storage */
   if (!simple.storage.links) simple.storage.links = {};
   Services.obs.notifyObservers(null, "openwebapps-mediator-init", "");

--- a/addons/jetpack/lib/main.js
+++ b/addons/jetpack/lib/main.js
@@ -38,6 +38,7 @@
 
 const tabs = require("tabs");
 const addon = require("self");
+const pageMod = require("page-mod");
 const unload = require("unload");
 const url = require("./urlmatch");
 const simple = require("simple-storage");
@@ -68,6 +69,9 @@ function openwebapps(win, getUrlCB) {
   tmp.InjectorInit(this._window);
   this._inject();
   win.appinjector.inject();
+  
+  // setup page-modes
+  this.setupManagerAPI();
 
   tmp = require("./services");
   this._services = new tmp.serviceInvocationHandler(this._window);
@@ -128,20 +132,7 @@ openwebapps.prototype = {
     let win = this._window;
     let self = this;
 
-    win.appinjector.register({
-      apibase: "navigator.mozApps",
-      name: "install",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(origin, data, onsuccess, onerror) {
-          let args = {
-            url: origin, install_data: data,
-            onsuccess: onsuccess, onerror: onerror
-          };
-          repo.install(contentWindowRef.location, args, win);
-        }
-      }
-    });
+    // XXX TODO these should only be injected into pages of installed apps
     win.appinjector.register({
       apibase: "navigator.mozApps",
       name: "amInstalled",
@@ -162,6 +153,22 @@ openwebapps.prototype = {
         }
       }
     });
+    
+    // global APIs that should be injected into all web content pages
+    win.appinjector.register({
+      apibase: "navigator.mozApps",
+      name: "install",
+      script: null,
+      getapi: function(contentWindowRef) {
+        return function(origin, data, onsuccess, onerror) {
+          let args = {
+            url: origin, install_data: data,
+            onsuccess: onsuccess, onerror: onerror
+          };
+          repo.install(contentWindowRef.location, args, win);
+        }
+      }
+    });
 
     win.appinjector.register({
       apibase: "navigator.mozApps",
@@ -173,106 +180,76 @@ openwebapps.prototype = {
         }
       }
     });
-
-    // management APIs:
-    win.appinjector.register({
-      apibase: "navigator.mozApps.mgmt",
-      name: "launch",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(args) {
-          repo.verifyMgmtPermission(contentWindowRef.location);
-          repo.launch(args);
-        }
-      }
-    });
-    win.appinjector.register({
-      apibase: "navigator.mozApps.mgmt",
-      name: "list",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(callback) {
-          repo.verifyMgmtPermission(contentWindowRef.location);
-          repo.list(callback);
-        }
-      }
-    });
-    win.appinjector.register({
-      apibase: "navigator.mozApps.mgmt",
-      name: "loginStatus",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(args) {
-          repo.verifyMgmtPermission(contentWindowRef.location);
-          return repo.loginStatus(args);
-        }
-      }
-    });
-    win.appinjector.register({
-      apibase: "navigator.mozApps.mgmt",
-      name: "loadState",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(callback) {
-          repo.verifyMgmtPermission(contentWindowRef.location);
-          repo.loadState(contentWindowRef.location, callback);
-        }
-      }
-    });
-    win.appinjector.register({
-      apibase: "navigator.mozApps.mgmt",
-      name: "saveState",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(state, callback) {
-          repo.verifyMgmtPermission(contentWindowRef.location);
-          repo.saveState(contentWindowRef.location, state, callback);
-        }
-      }
-    });
-    win.appinjector.register({
-      apibase: "navigator.mozApps.mgmt",
-      name: "uninstall",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(key, callback, onerror) {
-          repo.verifyMgmtPermission(contentWindowRef.location);
-          repo.uninstall(key, callback, onerror);
-        }
-      }
-    });
-    win.appinjector.register({
-      apibase: "navigator.mozApps.mgmt",
-      name: "watchUpdates",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(callback) {
-          repo.verifyMgmtPermission(contentWindowRef.location);
-          return repo.watchUpdates(contentWindowRef, callback);
-        }
-      }
-    });
-    win.appinjector.register({
-      apibase: "navigator.mozApps.mgmt",
-      name: "clearWatch",
-      script: null,
-      getapi: function(contentWindowRef) {
-        return function(id) {
-          repo.verifyMgmtPermission(contentWindowRef.location);
-          repo.clearWatch(contentWindowRef, id);
-        }
-      }
-    });
   },
 
   registerBuiltInApp: function(domain, app, injector) {
+    // XXX is anything using this call?  if dead remove it
     if (!this._repo) {
       if (!this.pendingRegistrations) this.pendingRegistrations = [];
       this.pendingRegistrations.push([domain, app, injector]);
     } else {
       this._repo._registerBuiltInApp(domain, app, injector);
     }
+  },
+  
+  setupManagerAPI: function() {
+    let repo = this._repo;
+
+    // XXX TODO if a manager app is installed,
+    // we need to add it to the allowedOrigins
+    let allowedOrigins = [
+      "https?://myapps.mozillalabs.com",
+      "*.myapps.mozillalabs.com",
+      "https?://apps.mozillalabs.com",
+      "https?://localhost",
+      "about:apps"
+    ];
+  
+    pageMod.PageMod({
+      include: allowedOrigins,
+      contentScriptWhen: 'start',
+      contentScriptFile: require("self").data.url("mgmtapi.js"),
+      onAttach: function onAttach(worker) {
+        worker.port.on("owa.mgmt.launch", function(msg) {
+          repo.launch(msg.data);
+        });
+        worker.port.on("owa.mgmt.list", function(msg) {
+          repo.list(function(apps) {
+            worker.port.emit(msg.success, apps)
+          });
+        });
+        worker.port.on("owa.mgmt.loginStatus", function(msg) {
+          let result = repo.loginStatus(msg.data);
+          worker.port.emit(msg.success, result);
+        });
+        worker.port.on("owa.mgmt.loadState", function(msg) {
+          repo.loadState(msg.location, function(value) {
+            worker.port.emit(msg.success, value)
+          });
+        });
+        worker.port.on("owa.mgmt.saveState", function(msg) {
+          repo.saveState(msg.location, msg.data, function(success) {
+            worker.port.emit(msg.success, success)
+          });
+        });
+        worker.port.on("owa.mgmt.uninstall", function(msg) {
+          repo.uninstall(msg.data, function(success) {
+            if (success)
+              worker.port.emit(msg.success, null);
+            else
+              worker.port.emit(msg.error, null);
+          });
+        });
+        worker.port.on("owa.mgmt.watchUpdates", function(msg) {
+          repo.watchUpdates(worker);
+        });
+        worker.port.on("owa.mgmt.clearWatch", function(msg) {
+          repo.clearWatch(worker);
+        });
+      }
+    });    
   }
+
 
 };
 

--- a/addons/jetpack/lib/services.js
+++ b/addons/jetpack/lib/services.js
@@ -89,25 +89,31 @@ function MediatorPanel(window, contentWindowRef, activity, successCB, errorCB) {
   this.isConfigured = false;
   this.invocationid = nextinvocationid++;
 
-  Services.obs.addObserver(this, 'content-document-global-created', false);
+  // we use document-element-inserted here rather than
+  // content-document-global-created so that other listeners using
+  // content-document-global-created will be called before us (e.g. injector.js
+  // needs to run first)
+  Services.obs.addObserver(this, 'document-element-inserted', false);
   this.contentScriptFile = [require("self").data.url("servicesapi.js")];
 
   this._createPopupPanel();
 }
 MediatorPanel.prototype = {
-  observe: function(contentWindow, aTopic, aData) {
-    if (aTopic != 'content-document-global-created' ||
-        !contentWindow.frameElement) return;
-    var id = contentWindow.frameElement.getAttribute('id');
+  observe: function(document, aTopic, aData) {
+    if (aTopic != 'document-element-inserted' ||
+        !document.defaultView.frameElement) return;
+    //console.log("mediator got documented created notification");
+    var id = document.defaultView.frameElement.getAttribute('id');
     for (var i=0; i < this.frames.length; i++) {
       if (id == this.frames[i].id) {
-        this.inject(contentWindow, this.frames[i]);
+        let frame = this.frames[i];
+        this.inject(document.defaultView, frame);
       }
     }
   },
   
   inject: function(contentWindow, frame) {
-    //dump("using content scripts "+JSON.stringify(this.contentScriptFile)+"\n");
+    //console.log("using content scripts "+JSON.stringify(this.contentScriptFile)+"\n");
     let worker =  Worker({
       window: contentWindow,
       contentScriptFile: this.contentScriptFile

--- a/addons/jetpack/test/helpers/helpers.js
+++ b/addons/jetpack/test/helpers/helpers.js
@@ -11,8 +11,8 @@ exports.getOWA = function() {
 }
 
 exports.getTestUrl = getTestUrl = function(testRelPath) {
-  let lastSlash = module.id.lastIndexOf("/");
-  return module.id.substr(0, lastSlash+1) + "../" + testRelPath;
+  let lastSlash = module.uri.lastIndexOf("/");
+  return module.uri.substr(0, lastSlash+1) + "../" + testRelPath;
 }
 
 function getTestAppOptions(appRelPath) {

--- a/addons/jetpack/test/test-services.js
+++ b/addons/jetpack/test/test-services.js
@@ -18,7 +18,7 @@ function getContentWindow() {
 TestMediator = {
   url: getTestUrl("apps/testable_mediator.html"),
   contentScript:
-    "window.navigator.mozApps.mediation.ready(function(activity, services) {" +
+    "window.navigator.wrappedJSObject.mozApps.mediation.ready(function(activity, services) {" +
     "  let service = services[0];" +
     // XXX - why is unsafeWindow needed here???
     "  unsafeWindow.document.getElementById('servicebox').appendChild(service.iframe);" +
@@ -120,7 +120,7 @@ exports.test_invoke_twice = function(test) {
 
 function makeErrorTestContentScript(methodName) {
   return "" +
-    "window.navigator.mozApps.mediation.ready(function(activity, services) {" +
+    "window.navigator.wrappedJSObject.mozApps.mediation.ready(function(activity, services) {" +
     "  let service = services[0];" +
     // XXX - why is unsafeWindow needed here???
     "  unsafeWindow.document.getElementById('servicebox').appendChild(service.iframe);" +


### PR DESCRIPTION
This removes global api's that are meant for specific content, updates injector.js to work like nsIDOMGlobalPropertyInitializer for the JavaScript-navigator-property category, providing backwards compat for pre-v9 firefox.
