### PR TITLE
Bug/fix html dialog on mobile

### DIFF
--- a/addons/jetpack/lib/sync.js
+++ b/addons/jetpack/lib/sync.js
@@ -280,10 +280,6 @@ SyncService.prototype.lastSyncTime = function () {
 };
 
 SyncService.prototype._setLastSyncTime = function (timestamp) {
-  if ((! timestamp) && timestamp !== 0) {
-    // FIXME: not sure if it should ever be valid not to give a timestamp
-    timestamp = new Date().getTime();
-  }
   if (typeof timestamp != 'number') {
     throw 'Must _setLastSyncTime to number (not ' + timestamp + ')';
   }
@@ -294,10 +290,6 @@ SyncService.prototype._setLastSyncTime = function (timestamp) {
 };
 
 SyncService.prototype._setLastSyncPut = function (timestamp) {
-  if ((! timestamp) && timestamp !== 0) {
-    // FIXME: not sure if it should ever be valid not to give a timestamp
-    timestamp = new Date().getTime();
-  }
   if (typeof timestamp != 'number') {
     throw 'Must _setLastSyncPut to number (not ' + timestamp + ')';
   }

--- a/site/jsapi/include.html
+++ b/site/jsapi/include.html
@@ -135,7 +135,7 @@ body
 </head>
 <body>
 <div id="installconfirm" class="dialog">
-  <div class="dialog-inner"
+  <div class="dialog-inner">
   <div id="header">
     <div id="repologo"><img src="logo.png"></div>
 
@@ -160,7 +160,7 @@ body
   </div>
   </div>
 </div>
-<div id="appchooser" class="dialog"
+<div id="appchooser" class="dialog">
   <div class="dialog-inner">
   Do you want to allow <span id="ac_requestor" class="requestor"></span>
   to "<span id="ac_service_name"></span>" with:

--- a/site/jsapi/include.html
+++ b/site/jsapi/include.html
@@ -17,13 +17,17 @@ body
 }
 
 .dialog {
-    position:fixed;
+    position: fixed;
     top: 0;
     left: 0;
- 	-moz-border-radius: 8px;
-    -webkit-border-radius: 8px;
-    border-radius: 8px 8px 8px 8px;
+    width: 410px;
+    -moz-border-radius: 1px;
+    -webkit-border-radius: 1px;
+    border-radius: 1px 1px 1px 1px;
     background-color: white;
+}
+
+.dialog-inner {
     margin: 8px;
 }
 
@@ -131,6 +135,7 @@ body
 </head>
 <body>
 <div id="installconfirm" class="dialog">
+  <div class="dialog-inner"
   <div id="header">
     <div id="repologo"><img src="logo.png"></div>
 
@@ -153,12 +158,15 @@ body
     <div id="cancelButton" class="nobutton button">Cancel</div>
     <div id="installButton" class="yesbutton button">Install</div>
   </div>
+  </div>
 </div>
-<div id="appchooser" class="dialog">
+<div id="appchooser" class="dialog"
+  <div class="dialog-inner">
   Do you want to allow <span id="ac_requestor" class="requestor"></span>
   to "<span id="ac_service_name"></span>" with:
   <ul id="ac_options">
   </ul>
+  </div>
 </div>
 <script>
 

--- a/site/jsapi/include.js
+++ b/site/jsapi/include.js
@@ -669,6 +669,16 @@ if (!navigator.mozApps.install || navigator.mozApps.html5Implementation) {
     // Called once on first command to create the iframe to myapps.mozillalabs.com
 
 
+    function isMobile() {
+      // FIXME: this doesn't detect mobile Firefox, but I'm not sure that
+      // mobile Firefox has the same issues (it could though)
+      var ua = navigator.userAgent;
+      if (ua.search(/AppleWebKit/) == -1) {
+        return false;
+      }
+      return ua.search(/iPhone|iPod|Android/) != -1;
+    }
+
     function setupWindow() {
       if (iframe) {
         return;
@@ -678,9 +688,17 @@ if (!navigator.mozApps.install || navigator.mozApps.html5Implementation) {
       var doc = win.document;
       iframe = document.createElement("iframe");
       iframe.id = dialogId;
-      iframe.style.position = "fixed";
+      if (isMobile()) {
+        iframe.style.position = "absolute";
+      } else {
+        iframe.style.position = "fixed";
+      }
       iframe.style.left = "50%";
-      iframe.style.top = "40%";
+      if (isMobile()) {
+        iframe.style.top = (window.pageYOffset + 166) + 'px';
+      } else {
+        iframe.style.top = "40%";
+      }
       iframe.style.width = "410px";
       iframe.style.marginLeft = "-205px"; // half of the previous value
       iframe.style.height = "332px";


### PR DESCRIPTION
Fixes how the install confirmation dialog looks on mobile WebKit (it's pretty broken without this).

Tested only on Android, not Mobile Safari.
