### PR TITLE
Bug/711131 implement html uninstall

### DIFF
--- a/addons/jetpack/lib/api.js
+++ b/addons/jetpack/lib/api.js
@@ -135,7 +135,10 @@ FFRepoImpl.prototype = {
             skipPostInstallDashboard: true
           })
         );
-        self._callWatchers("add", [apprec]);  
+        self._callWatchers("add", [apprec]);
+      }
+      if (cb) {
+        cb(success);
       }
     })
   },
@@ -159,12 +162,12 @@ FFRepoImpl.prototype = {
     };
 
     try {
-      xhr.send(null); 
+      xhr.send(null);
     } catch (e) {
       console.log("XHR in fetchManifest threw " + e);
       cb(null);
     }
-    
+
     let timer = Cc["@mozilla.org/timer;1"].createInstance(Ci.nsITimer);
     timer.initWithCallback({
       notify: function(timer) {
@@ -208,7 +211,7 @@ FFRepoImpl.prototype = {
       noNativeButton.callback = function() {
         // Don't generate a native app
         _makeNativeApp = false;
-        installConfirmationFinishFn(true);  
+        installConfirmationFinishFn(true);
       };
 
       let ret = window.PopupNotifications.show(

--- a/site/jsapi/include.js
+++ b/site/jsapi/include.js
@@ -1049,6 +1049,7 @@ if (!navigator.mozApps.install || navigator.mozApps.html5Implementation) {
         ready: callReady,
         registerHandler: callRegisterHandler
       },
+      uninstall: callUninstall,
       html5Implementation: true
     };
     if (TESTING_MODE) {

--- a/site/tests/spec/repo_api.html
+++ b/site/tests/spec/repo_api.html
@@ -84,6 +84,7 @@ navigator.mozApps.mgmt.launch
 navigator.mozApps.mgmt.list...
 navigator.mozApps.mgmt.uninstall
 navigator.mozApps.mgmt.watchUpdates
+navigator.mozApps.uninstall
 </pre>
 </section>
 
@@ -102,7 +103,7 @@ $ function uninstallAll() {
 >     var total = m.length;
 >     finished = (total === 0);
 >     for (var i=0; i&lt;m.length; i++) {
->       navigator.mozApps.mgmt.uninstall(m[i].origin, function(r) {
+>       navigator.mozApps.uninstall(m[i].origin, function(r) {
 >         finished = (--total === 0);
 >       }, function (e) {
 >         finished = true;
@@ -131,7 +132,7 @@ apps.mgmt.list([])
 <h3>Uninstall non-existant app should fail</h3>
 
 <pre class="doctest">
-$ navigator.mozApps.mgmt.uninstall("http://not.really.installed",
+$ navigator.mozApps.uninstall("http://not.really.installed",
 >      Spy('uninstall/success', {wait: false, wrapArgs: true}),
 >      Spy('uninstall/failure', {wait: true, wrapArgs: true}));
 uninstall/failure({
@@ -386,7 +387,7 @@ error("permissionDenied", "to access open web apps management apis, you must be 
 <section class="test">
 <h3>Verify proper errors from uninstall()</h3>
 <pre class="doctest">
-$ navigator.mozApps.mgmt.uninstall(
+$ navigator.mozApps.uninstall(
 >    "http://nosuch.app",
 >    Spy('success', {wait: false}),
 >    Spy('error', {wait: true}));
@@ -403,7 +404,7 @@ an app (basic_app), wait 100ms, and then verify that list returns a
 single app.</p>
 
 <pre class="doctest">
-$ navigator.mozApps.mgmt.uninstall(SERVERS['basic_app']);
+$ navigator.mozApps.uninstall(SERVERS['basic_app']);
 > wait(100);
 $ navigator.mozApps.mgmt.list(Spy('list', {wait: true, wrapArgs: true}));
 list([
@@ -484,7 +485,7 @@ watchUpdates("add", [
   }
 ])
 apps.install()
-$ navigator.mozApps.mgmt.uninstall(SERVERS['basic_app'], Spy('apps.uninstall', {wait: true}));
+$ navigator.mozApps.uninstall(SERVERS['basic_app'], Spy('apps.uninstall', {wait: true}));
 watchUpdates("remove", [
   {
     install_origin: "http://127.0.0.1:?",


### PR DESCRIPTION
This implements only the HTML implementation of navigator.mozApps.uninstall(), while also leaving in mgmt.uninstall

https://bugzilla.mozilla.org/show_bug.cgi?id=711131
