### PR TITLE
A patch to parameterize the dashboard location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,13 @@ else
   cfx_args :=  --pkgdir=$(pkgdir) $(binary) $(profile) --binary-args="-console -purgecaches $(BINARYARGS)"
 endif
 
+ifeq ($(DASHBOARD),)
+  cfx_args += --static-args="{ \"dashboard\": \"myapps.mozillalabs.com\" }"
+else
+  dashboard := $(DASHBOARD)
+  cfx_args += --static-args="{ \"dashboard\": \"$(dashboard)\" }"
+endif
+
 test_args :=
 ifneq ($(TEST),)
     test_args := -f $(TEST)

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,11 @@ else
   cfx_args :=  --pkgdir=$(pkgdir) $(binary) $(profile) --binary-args="-console -purgecaches $(BINARYARGS)"
 endif
 
-ifeq ($(DASHBOARD),)
-  cfx_args += --static-args="{ \"dashboard\": \"myapps.mozillalabs.com\" }"
-else
-  cfx_args += --static-args="{ \"dashboard\": \"$(DASHBOARD)\" }"
+# Ability to pass in a list of static args in json format
+# Ex: export STATIC_ARGS='\"dashboard\":\"myapps.mozillalabs.com\", \"appsyncurl\":\"https://myapps.mozillalabs.com\"' 
+
+ifneq ($(STATIC_ARGS),)
+  cfx_args += --static-args="{$(STATIC_ARGS)}"
 endif
 
 test_args :=

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,7 @@ endif
 ifeq ($(DASHBOARD),)
   cfx_args += --static-args="{ \"dashboard\": \"myapps.mozillalabs.com\" }"
 else
-  dashboard := $(DASHBOARD)
-  cfx_args += --static-args="{ \"dashboard\": \"$(dashboard)\" }"
+  cfx_args += --static-args="{ \"dashboard\": \"$(DASHBOARD)\" }"
 endif
 
 test_args :=

--- a/addons/jetpack/lib/main.js
+++ b/addons/jetpack/lib/main.js
@@ -45,7 +45,7 @@ const simple = require("simple-storage");
 const { Cc, Ci, Cm, Cu, Cr, components } = require("chrome");
 
 const TOOLBAR_ID = "openwebapps-toolbar-button";
-const APP_SYNC_URL = "https://myapps.mozillalabs.com";
+var APP_SYNC_URL = "https://myapps.mozillalabs.com";
 
 var tmp = {};
 Cu.import("resource://gre/modules/Services.jsm", tmp);
@@ -53,12 +53,18 @@ Cu.import("resource://gre/modules/AddonManager.jsm", tmp);
 Cu.import("resource://gre/modules/XPCOMUtils.jsm", tmp);
 var { XPCOMUtils, AddonManager, Services } = tmp;
 
-var DASHBOARD_URL;
-var DASHBOARD_HOST;
+var DASHBOARD_URL = "myapps.mozillalabs.com";
+var DASHBOARD_HOST = "https://myapps.mozillalabs.com";
 
 exports.main = function(options, callbacks) {
-  DASHBOARD_HOST = options.staticArgs.dashboard;
-  DASHBOARD_URL = "http://" + DASHBOARD_HOST;
+  
+  if(options.staticArgs.dashboard) {
+    DASHBOARD_HOST = options.staticArgs.dashboard;
+    DASHBOARD_URL = "https://" + DASHBOARD_HOST;
+  }
+  if(options.staticArgs.appsyncurl) {
+    APP_SYNC_URL = options.staticArgs.appsyncurl;
+  }
 }
 
 /**

--- a/addons/jetpack/lib/main.js
+++ b/addons/jetpack/lib/main.js
@@ -53,6 +53,14 @@ Cu.import("resource://gre/modules/AddonManager.jsm", tmp);
 Cu.import("resource://gre/modules/XPCOMUtils.jsm", tmp);
 var { XPCOMUtils, AddonManager, Services } = tmp;
 
+var DASHBOARD_URL;
+var DASHBOARD_HOST;
+
+exports.main = function(options, callbacks) {
+  DASHBOARD_HOST = options.staticArgs.dashboard;
+  DASHBOARD_URL = "http://" + tmp.dashboard;
+}
+
 /**
  * openwebapps
  *
@@ -144,8 +152,8 @@ openwebapps.prototype = {
     // XXX TODO if a manager app is installed,
     // we need to add it to the allowedOrigins
     let allowedOrigins = [
-      "https?://myapps.mozillalabs.com",
-      "*.myapps.mozillalabs.com",
+      "https?://" + DASHBOARD_HOST,
+      "*." + DASHBOARD_HOST,
       "https?://apps.mozillalabs.com",
       "https?://localhost",
       "http://127.0.0.1:60172/*",
@@ -371,7 +379,7 @@ function setupLogin(service, scheduler) {
 
   /* Only show panel when on dashbord page and not loggedIn */
   function showPanel(tab) {
-    let dboard = "https://myapps.mozillalabs.com";
+    let dboard = DASHBOARD_URL;
     if (tab.url.slice(0, dboard.length) == dboard) {
       if (loggingIn) return;
       if (!service.loggedIn()) {
@@ -394,7 +402,7 @@ function migrateApps() {
   try {
     console.log("Creating page worker");
     var worker = pageWorkers.Page({
-      contentURL: "https://myapps.mozillalabs.com",
+      contentURL: DASHBOARD_URL,
       contentScript: "var apps = [];" +
         "for (var i = 0; i < localStorage.length; i++) {" +
         " var key = localStorage.key(i);" +
@@ -506,11 +514,11 @@ function startup(getUrlCB) { /* Initialize simple storage */
       let found = false;
       for each (let tab in tabs) {
         let origin = url.URLParse(tab.url).originOnly().toString();
-        if (origin == "https://myapps.mozillalabs.com") {
+        if (origin == DASHBOARD_URL) {
           tab.activate(); found = true; break;
         }
       }
-      if (!found) tabs.open("https://myapps.mozillalabs.com");
+      if (!found) tabs.open(DASHBOARD_URL);
     }
   });
 

--- a/addons/jetpack/lib/main.js
+++ b/addons/jetpack/lib/main.js
@@ -53,8 +53,8 @@ Cu.import("resource://gre/modules/AddonManager.jsm", tmp);
 Cu.import("resource://gre/modules/XPCOMUtils.jsm", tmp);
 var { XPCOMUtils, AddonManager, Services } = tmp;
 
-var DASHBOARD_URL = "myapps.mozillalabs.com";
-var DASHBOARD_HOST = "https://myapps.mozillalabs.com";
+var DASHBOARD_URL = "https://myapps.mozillalabs.com";
+var DASHBOARD_HOST = "myapps.mozillalabs.com";
 
 exports.main = function(options, callbacks) {
   

--- a/addons/jetpack/lib/main.js
+++ b/addons/jetpack/lib/main.js
@@ -58,7 +58,7 @@ var DASHBOARD_HOST;
 
 exports.main = function(options, callbacks) {
   DASHBOARD_HOST = options.staticArgs.dashboard;
-  DASHBOARD_URL = "http://" + tmp.dashboard;
+  DASHBOARD_URL = "http://" + DASHBOARD_HOST;
 }
 
 /**


### PR DESCRIPTION
Wrote a patch that changes the makefile process, and the extension to parameterize the dashboard location.

This should allow us to set the dashboard through the build process. 

Needs review, specifically around the addon change in main.js, and the use of a global variable to store the hostname. 
