### PR TITLE
Update examples/mozillaball/index.html to new API

### DIFF
--- a/examples/mozillaball/index.html
+++ b/examples/mozillaball/index.html
@@ -98,26 +98,28 @@ be wrapped up as an Open Web App.<br><br>
 var gManifestName = "/manifest.webapp";
 
 $(document).ready(function() {
-    navigator.apps.amInstalled(function(result) {
-        if (!result) {
-            $("#install_button").show();
+  var request = navigator.mozApps.getSelf();
+	request.onsuccess = function() {
+	  if (request.result) {
+	    // we're installed
+	    $("#install_button").text("INSTALLED!").show();
+	  } else {
+	    // not installed
+	    $("#install_button").show();
             $("#install_button").click(function() {
-                navigator.apps.install({
-                  url: gManifestName,
-                  onsuccess: function() {
+		var req = navigator.mozApps.install(gManifestName);
+		req.onsuccess = function() {
                     $("#install_button").text("INSTALLED!").unbind('click');
-                  },
-                  onerror: function(errObj) {
+                }
+		req.onerror = function(errObj) {
                     alert("Couldn't install (" + errObj.code + ") " + errObj.message);
-                  }
-                });
+                }
             });
-        } else {
-            $("#install_button").text("INSTALLED!").show();
-
-        }
-    });
-
+	  }
+	}
+	request.onerror = function() {
+	  alert('Error checking installation status: ' + this.error.message);
+	}
 });
 
 </script>


### PR DESCRIPTION
Substitute old API calls like navigator.apps.amInstalled() and navigator.apps.install() with new API using navigator.mozApps.getSelf() and navigator.mozApps.install().
